### PR TITLE
Wrap all random forest `seed` argument defaults in expr()

### DIFF
--- a/R/rand_forest_data.R
+++ b/R/rand_forest_data.R
@@ -43,7 +43,7 @@ rand_forest_ranger_data <-
           object = quote(object$fit),
           data = quote(new_data),
           type = "response",
-          seed = sample.int(10^5, 1),
+          seed = expr(sample.int(10^5, 1)),
           verbose = FALSE
         )
     ),
@@ -56,7 +56,7 @@ rand_forest_ranger_data <-
           object = quote(object$fit),
           data = quote(new_data),
           type = "response",
-          seed = sample.int(10^5, 1),
+          seed = expr(sample.int(10^5, 1)),
           verbose = FALSE
         )
     ),
@@ -77,7 +77,7 @@ rand_forest_ranger_data <-
         list(
           object = quote(object$fit),
           data = quote(new_data),
-          seed = sample.int(10^5, 1),
+          seed = expr(sample.int(10^5, 1)),
           verbose = FALSE
         )
     ),


### PR DESCRIPTION
As discussed on our call, `seed` arguments should be wrapped in `expr()`.

I've also found this one:
https://github.com/topepo/parsnip/blob/master/R/mlp_data.R#L137

Should I do the same thing here?
