### PR TITLE
Fix/protect core model args

### DIFF
--- a/R/arguments.R
+++ b/R/arguments.R
@@ -70,10 +70,11 @@ prune_arg_list <- function(x, whitelist = NULL, modified = character(0)) {
   x
 }
 
-check_others <- function(args, obj) {
+check_others <- function(args, obj, core_args) {
   # Make sure that we are not trying to modify an argument that
-  # is explicitly protected in the method metadata
-  common_args <- intersect(obj$protect, names(args))
+  # is explicitly protected in the method metadata or arg_key
+  protected_args <- unique(c(obj$protect, core_args))
+  common_args <- intersect(protected_args, names(args))
   if (length(common_args) > 0) {
     args <- args[!(names(args) %in% common_args)]
     common_args <- paste0(common_args, collapse = ", ")

--- a/R/translate.R
+++ b/R/translate.R
@@ -59,7 +59,8 @@ translate.default <- function(x, engine, ...) {
   # check secondary arguments to see if they are in the final
   # expression unless there are dots, warn if protected args are
   # being altered
-  x$others <- check_others(x$others, x$method$fit)
+  eng_arg_key <- arg_key[[x$engine]]
+  x$others <- check_others(x$others, x$method$fit, eng_arg_key)
 
   # keep only modified args
   modifed_args <- !vapply(actual_args, null_value, lgl(1))

--- a/tests/testthat/test_rand_forest_ranger.R
+++ b/tests/testthat/test_rand_forest_ranger.R
@@ -11,7 +11,7 @@ num_pred <- c("funded_amnt", "annual_inc", "num_il_tl")
 lc_basic <- rand_forest()
 lc_ranger <- rand_forest(others = list(seed = 144))
 
-bad_ranger_cls <- rand_forest(others = list(min.node.size = -10))
+bad_ranger_cls <- rand_forest(others = list(replace = "bad"))
 bad_rf_cls <- rand_forest(others = list(sampsize = -10))
 
 ctrl <- fit_control(verbosity = 1, catch = FALSE)
@@ -160,7 +160,7 @@ num_pred <- names(mtcars)[3:6]
 
 car_basic <- rand_forest()
 
-bad_ranger_reg <- rand_forest(others = list(min.node.size = -10))
+bad_ranger_reg <- rand_forest(others = list(replace = "bad"))
 bad_rf_reg <- rand_forest(others = list(sampsize = -10))
 
 ctrl <- list(verbosity = 1, catch = FALSE)


### PR DESCRIPTION
This PR closes #67.

In the `translate()` step where the rest of the protection checks are done, we now also protect the core arguments of any model (aka any args in the `arg_key`)